### PR TITLE
fix a typo in doc

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -103,12 +103,12 @@ Here, we demonstrate creating the subsetted promoter annotation for the Human ge
 
 ```{r CreateAnnotation, eval=FALSE}
 ## From GTF file path
-gtf.file <- system.file('extdata/vignette/annotation/gencode.v34.annotation.subset.gtf.gz', 
+gtf.file <- system.file('extdata/vignette/annotations/gencode.v34.annotation.subset.gtf.gz', 
                         package = 'proActiv')
 promoterAnnotation.gencode.v34.subset <- preparePromoterAnnotation(file = gtf.file,
                                                                    species = 'Homo_sapiens')
 ## From TxDb object
-txdb.file <- system.file('extdata/vignette/annotation/gencode.v34.annotation.subset.sqlite', 
+txdb.file <- system.file('extdata/vignette/annotations/gencode.v34.annotation.subset.sqlite', 
                          package = 'proActiv')
 txdb <- loadDb(txdb.file)
 promoterAnnotation.gencode.v34.subset <- preparePromoterAnnotation(txdb = txdb, 


### PR DESCRIPTION
error is found in (### Creating a Promoter Annotation object)

"annotation" -> "annotations" 


![image](https://user-images.githubusercontent.com/94505605/150450563-836ffa8a-0946-4060-88c6-4ca38bfc11ae.png)


